### PR TITLE
Fix type alias ruff warning

### DIFF
--- a/typing.py
+++ b/typing.py
@@ -4,6 +4,5 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TypeAlias
 
-PathLike: TypeAlias = Path | str
+type PathLike = Path | str


### PR DESCRIPTION
## Summary
- use `type` keyword for `PathLike`

## Testing
- `uv run black --check .`
- `uv run ruff check typing.py`
- `uv run pyright typing.py`

------
https://chatgpt.com/codex/tasks/task_e_685b3483ccb08325a56aed2bd0f84189