### PR TITLE
Rename logging module to logs

### DIFF
--- a/command_line_interface.py
+++ b/command_line_interface.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from sys import argv
 from typing import Any
 
-from .logging import set_logging_verbosity
+from .logs import set_logging_verbosity
 
 
 class CommandLineInterface(ABC):

--- a/logs.py
+++ b/logs.py
@@ -1,6 +1,6 @@
 #  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""General-purpose functions not tied to a particular project."""
+"""Logging utilities."""
 from __future__ import annotations
 
 from logging import DEBUG, ERROR, INFO, WARNING, basicConfig, getLogger


### PR DESCRIPTION
## Summary
- rename `logging.py` to `logs.py` to avoid name clash
- update CLI imports to use `logs` module

## Testing
- `uv run black .`
- `uv run ruff check .`
- `uv run pyright`


------
https://chatgpt.com/codex/tasks/task_e_685b354797e08325bb62dbc687e88e54