### PR TITLE
Expose helpers via __all__

### DIFF
--- a/argument_parsing.py
+++ b/argument_parsing.py
@@ -246,3 +246,21 @@ def str_arg(**kwargs: Any) -> Callable[[Any], str]:
         Value validator function
     """
     return get_validator(validate_str, **kwargs)
+
+
+__all__ = [
+    "float_arg",
+    "get_arg_groups_by_name",
+    "get_optional_arguments_group",
+    "get_required_arguments_group",
+    "get_validator",
+    "input_directories_arg",
+    "input_directory_arg",
+    "input_file_arg",
+    "input_files_arg",
+    "int_arg",
+    "ints_arg",
+    "output_directory_arg",
+    "output_file_arg",
+    "str_arg",
+]

--- a/file.py
+++ b/file.py
@@ -66,3 +66,10 @@ def rename_preexisting_output_path(output_path: Path) -> None:
                 move(output_path, backup_path)
                 break
             backup_i += 1
+
+
+__all__ = [
+    "get_temp_directory_path",
+    "get_temp_file_path",
+    "rename_preexisting_output_path",
+]

--- a/general.py
+++ b/general.py
@@ -128,3 +128,9 @@ def run_command_live(
             )
 
     return exitcode, stdout_str, stderr_str
+
+
+__all__ = [
+    "run_command",
+    "run_command_live",
+]

--- a/logs.py
+++ b/logs.py
@@ -22,3 +22,8 @@ def set_logging_verbosity(verbosity: int) -> None:
         getLogger().setLevel(level=INFO)
     elif verbosity >= 3:
         getLogger().setLevel(level=DEBUG)
+
+
+__all__ = [
+    "set_logging_verbosity",
+]

--- a/validation.py
+++ b/validation.py
@@ -347,3 +347,19 @@ def validate_type(value: Any, cls: Any) -> Any:
     if not isinstance(value, cls):
         raise TypeError(f"'{value}' is of type '{type(value)}', not {cls.__name__}")
     return value
+
+
+__all__ = [
+    "validate_executable",
+    "validate_float",
+    "validate_input_directories",
+    "validate_input_directory",
+    "validate_input_file",
+    "validate_input_files",
+    "validate_int",
+    "validate_ints",
+    "validate_output_directory",
+    "validate_output_file",
+    "validate_str",
+    "validate_type",
+]


### PR DESCRIPTION
## Summary
- add `__all__` to helper modules so public helpers are discoverable
- alphabetize the members of each list
- ensure a trailing comma even for single-element lists

## Testing
- `uv run black . --check`
- `uv run ruff check .`
- `uv run pyright`


------
https://chatgpt.com/codex/tasks/task_e_68780a3e54308325a9180a5063ffc462