### PR TITLE
Fix TypeError messages in validation functions

### DIFF
--- a/validation.py
+++ b/validation.py
@@ -75,7 +75,7 @@ def validate_float(
         return_value = float(value)
     except ValueError as error:
         raise TypeError(
-            f"{value} is of type {type(value)}, cannot be cast to int"
+            f"{value} is of type {type(value)}, cannot be cast to float"
         ) from error
 
     if min_value and return_value < min_value:
@@ -198,7 +198,7 @@ def validate_int(
         return_value = int(value)
     except ValueError as error:
         raise TypeError(
-            f"{value} is of type {type(value)}, cannot be cast to float"
+            f"{value} is of type {type(value)}, cannot be cast to int"
         ) from error
 
     if min_value and return_value < min_value:


### PR DESCRIPTION
## Summary
- correct TypeError messages in `validate_float` and `validate_int`

## Testing
- `uv run ruff format validation.py`
- `uv run ruff check --fix validation.py`
- `uv run pyright validation.py`
- `PYTHONPATH=$PWD uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782414bdec8325b792fbd74e53dba6