### PR TITLE
Fix validate_input_file docstring

### DIFF
--- a/validation.py
+++ b/validation.py
@@ -132,7 +132,8 @@ def validate_input_file(path: PathLike, must_exist: bool = True) -> Path:
 
     Arguments:
         path: Path to input file
-        must_exist: If True, do not raise an error if the file does not exist
+        must_exist: If True, raise an error if the file does not exist; if False,
+            allow missing files
     Returns:
         Absolute path to input file
     """


### PR DESCRIPTION
## Summary
- clarify `validate_input_file` behavior when `must_exist` is True or False

## Testing
- `uv run ruff format validation.py`
- `uv run ruff check --fix validation.py`
- `uv run pyright validation.py`
- `PYTHONPATH=$(pwd) uv run pytest -q common/tests`

------
https://chatgpt.com/codex/tasks/task_e_68782424758c832580896aae22f0771e