### PR TITLE
Fix validate_ints annotation

### DIFF
--- a/validation.py
+++ b/validation.py
@@ -217,7 +217,7 @@ def validate_ints(
     min_value: int | None = None,
     max_value: int | None = None,
     options: Collection[int] | None = None,
-):
+) -> list[int]:
     """Validate a collection of int.
 
     Arguments:


### PR DESCRIPTION
## Summary
- annotate return type of `validate_ints`

## Testing
- `uv run ruff format validation.py`
- `uv run ruff check --fix validation.py`
- `uv run pyright validation.py`
- `PYTHONPATH=/workspace uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782f2e9f548325bc98cf2cfd98c808